### PR TITLE
Condorcet based methods are vulnerable to irrelevant alternatives in case of missing candidates in ballots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * [API-BREAK] `CheckedPoll` has been removed because no longer necessary due to changes of poll and ballots (see above)
 
 ### Fixed
-* Consider missing candidates in ballots as abstentions for candidates pairwise matches.
+* Graph based methods was vulnerable to irrelevant alternatives in case of missing candidates in ballots.
+  It has been solved by counting missing candidates as abstentions in pairwise matches.
 
 ### Dependencies changes
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Removed
 * [API-BREAK] `CheckedPoll` has been removed because no longer necessary due to changes of poll and ballots (see above)
 
+### Fixed
+* Consider missing candidates in ballots as abstentions for candidates pairwise matches.
+
 ### Dependencies changes
 #### Added
 * [Kable](https://github.com/slimaku/kable) 1.1.0

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  precision: 0         # how many decimal places to display in the UI: 0 <= value <= 4
+  round: up            # how coverage is rounded: down/up/nearest
+  range: 50...80      # custom range of coverage colors from red -> yellow -> green
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        enabled: yes           # must be yes|true to enable this status
+        target: 80%            # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+
+    patch:                     # pull requests only: this commit status will measure the
+                               # entire pull requests Coverage Diff. Checking if the lines
+                               # adjusted are covered at least X%.
+      default:
+        enabled: yes             # must be yes|true to enable this status
+        target: 80%              # specify the target "X%" coverage to hit
+
+  ignore:          # files and folders that will be removed during processing
+    - "tests/*"
+    - "demo/*.rb"
+
+  fixes:           # [advanced] in rare cases the report tree is invalid, specify adjustments here
+    - "old_path::new_path"

--- a/src/main/kotlin/kondorcet/graph/Graph.kt
+++ b/src/main/kotlin/kondorcet/graph/Graph.kt
@@ -1,6 +1,7 @@
 package kondorcet.graph
 
 import kable.Table
+import kable.count
 
 /**
  * Directed and weighted graph
@@ -30,18 +31,17 @@ internal interface Graph<V : Any, out W : Any> {
      */
     operator fun get(source: V, target: V): W? = edges[source, target]
 
-    /**
-     * Returns the edges having the [source] vertex
-     */
+    /** Returns the edges having the [source] vertex */
     fun getEdgesFrom(source: V): Map<V, W> = edges.getRow(source)
 
-    /**
-     * Returns the edges having the [target] vertex
-     */
+    /** Returns the edges having the [target] vertex */
     fun getEdgesTo(target: V): Map<V, W> = edges.getColumn(target)
 
     /** Returns the number of edges having the [source] vertex */
     fun getDegreeFrom(source: V): Int = getEdgesFrom(source).size
+
+    /** Returns the number of edges having the [vertex] as it source or target */
+    fun getDegreeOf(vertex: V): Int = edges.count { (row, column, _) -> vertex == row || vertex == column }
 
     /** Returns the number of edges having the [target] vertex */
     fun getDegreeTo(target: V): Int = getEdgesTo(target).size

--- a/src/test/kotlin/kondorcet/CondorcetProofMethodTest.kt
+++ b/src/test/kotlin/kondorcet/CondorcetProofMethodTest.kt
@@ -52,4 +52,34 @@ abstract class CondorcetProofMethodTest {
 
         Assert.assertEquals(expected, actual)
     }
+
+    @Test
+    fun testMissedCandidate() {
+        val poll = pollOf(
+                ballot('A', 'C', 'B') to 23,
+                ballot('B', 'C', 'A') to 19,
+                ballot('C', 'B', 'A') to 16,
+                ballot('C', 'A', 'B') to 2
+        ) + ballot('D', 'A', 'B', 'C')
+
+        val expected = ballot('C', 'B', 'A')
+        val actual = poll.getResult(method)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testEqualyPreferredCandidate() {
+
+        val poll = pollOf(
+                ballot('A', 'B', 'C') to 10,
+                ballot(listOf(setOf('A', 'B'), setOf('C'))) to 5,
+                ballot('C', 'B', 'A') to 9
+        )
+
+        val expected = ballot('A', 'B', 'C')
+        val actual = poll.getResult(method)
+
+        Assert.assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
After this PR, missing candidates in ballots will be counted as abstentions for pairwise matches.

Resolves #12 